### PR TITLE
classifier_dropout bug fix

### DIFF
--- a/evaluation/clone_detection.py
+++ b/evaluation/clone_detection.py
@@ -100,7 +100,9 @@ def main():
     config.problem_type = "single_label_classification"
     config.num_labels = 2
     config.classifier_dropout = None
-    model = AutoModelForSequenceClassification.from_pretrained(args.model_name_or_path, trust_remote_code=True)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        args.model_name_or_path, config=config, trust_remote_code=True
+    )
 
     if args.freeze:
         print("Freezing model parameters")

--- a/evaluation/complexity_prediction.py
+++ b/evaluation/complexity_prediction.py
@@ -114,7 +114,9 @@ def main():
     config.problem_type = "single_label_classification"
     config.num_labels = 7
     config.classifier_dropout = None
-    model = AutoModelForSequenceClassification.from_pretrained(args.model_name_or_path, trust_remote_code=True)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        args.model_name_or_path, config=config, trust_remote_code=True
+    )
 
     if args.freeze:
         print("Freezing model parameters")

--- a/evaluation/defect_prediction.py
+++ b/evaluation/defect_prediction.py
@@ -105,7 +105,9 @@ def main():
     config.problem_type = "single_label_classification"
     config.num_labels = 2
     config.classifier_dropout = None
-    model = AutoModelForSequenceClassification.from_pretrained(args.model_name_or_path, trust_remote_code=True)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        args.model_name_or_path, config=config, trust_remote_code=True
+    )
 
     if args.freeze:
         print("Freezing model parameters")

--- a/evaluation/runtime_error_prediction.py
+++ b/evaluation/runtime_error_prediction.py
@@ -147,7 +147,9 @@ def main():
     config.problem_type = "single_label_classification"
     config.num_labels = 29
     config.classifier_dropout = None
-    model = AutoModelForSequenceClassification.from_pretrained(args.model_name_or_path, trust_remote_code=True)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        args.model_name_or_path, config=config, trust_remote_code=True
+    )
 
     if args.freeze:
         print("Freezing model parameters")


### PR DESCRIPTION
*Issue #, if available:*
#4
*Description of changes:*
Instead of 
```
model = AutoModelForSequenceClassification.from_pretrained(args.model_name_or_path, trust_remote_code=True)
```
we should use:
```
model = AutoModelForSequenceClassification.from_pretrained(
    args.model_name_or_path, config=config, trust_remote_code=True
)
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
